### PR TITLE
Log exception when parsing callback URL fails

### DIFF
--- a/lib/straight-server/gateway.rb
+++ b/lib/straight-server/gateway.rb
@@ -238,7 +238,12 @@ module StraightServer
 
         # Composing the request uri here
         callback_data = order.callback_data ? "&callback_data=#{CGI.escape(order.callback_data)}" : ''
-        uri           = URI.parse("#{url}#{url.include?('?') ? '&' : '?'}#{order.to_http_params}#{callback_data}")
+        begin
+          uri = URI.parse("#{url}#{url.include?('?') ? '&' : '?'}#{order.to_http_params}#{callback_data}")
+        rescue => ex
+          StraightServer.logger.warn "Parse callback URI failed with #{ex.inspect}"
+          return
+        end
 
         StraightServer.logger.info "Attempting callback for order #{order.id}: #{uri.to_s}"
 


### PR DESCRIPTION
Hello,

1. In `send_callback_http_request`, if `URI.parse` raises an exception (on invalid callback URL), seems the method will quit silently. When this situation happens, the logs could lead to a confusing conclusion that the status checking is stuck. Do you think if it would be ideal to catch the exception and report the error, helping locate the problem? This pull request is an attempt to explain the situation.
1. Not related to this pull request, wondering if it's possible to make `send_callback_http_request` support Docker compose-like names in the domain of the callback URL, like `http://compose_straight_1:8080`? Actually we were feeding `URI.parse` such a Docker compose URL, and it led to the problem above. Made a quick fix which involved an [external library "Addressable"](https://github.com/sporkmonger/addressable) though, changes not included in the commit but being pasted below.

    ```
    require "addressable/uri"

    ...

    begin
      uri = Addressable::URI.parse("#{url}#{url.include?('?') ? '&' : '?'}#{order.to_http_params}#{callback_data}")
    rescue => ex
      StraightServer.logger.warn "Parse callback URI failed with #{ex.inspect}"
      return
    end

    ...

    ```
   
Thank you!