### PR TITLE
do not trigger order_callbacks for mutable statuses

### DIFF
--- a/lib/straight-server/gateway.rb
+++ b/lib/straight-server/gateway.rb
@@ -187,6 +187,7 @@ module StraightServer
         increment_order_counter!(statuses[order.old_status], -1) if order.old_status
         increment_order_counter!(statuses[order.status])
       end
+      return if order.status < 0
       super
     end
 


### PR DESCRIPTION
This fixes websocket disconnect after the partial payment.