### PR TITLE
Fix: Add amount with currency to orders

### DIFF
--- a/db/migrations/31_add_amount_with_currency_to_orders.rb
+++ b/db/migrations/31_add_amount_with_currency_to_orders.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    add_column :orders, :amount_with_currency, String
+  end
+
+  down do
+    drop_column :orders, :amount_with_currency
+  end
+end

--- a/db/migrations/32_remove_exchange_rate_and_currency_from_orders.rb
+++ b/db/migrations/32_remove_exchange_rate_and_currency_from_orders.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    drop_column :orders, :exchange_rate
+    drop_column :orders, :currency
+  end
+
+  down do
+    add_column :orders, :exchange_rate, BigDecimal
+    add_column :orders, :currency, String
+  end
+end

--- a/lib/straight-server/order.rb
+++ b/lib/straight-server/order.rb
@@ -189,7 +189,7 @@ module StraightServer
       self.payment_id = gateway.sign_with_secret("#{keychain_id}#{amount}#{created_at}#{(Order.max(:id) || 0)+1}")
 
       # Save info about current exchange rate at the time of purchase
-      unless gateway.default_currency == 'BTC'
+      if !gateway.address_provider.takes_fees? && gateway.default_currency != 'BTC'
         self.data = {} unless self.data
         self.data[:exchange_rate] = { price: gateway.current_exchange_rate, currency: gateway.default_currency }
       end


### PR DESCRIPTION
Related to https://github.com/MyceliumGear/straight/pull/20

* Add the `amount_with_currency` string column to orders.
* Don't save the exchange rate for Order payout providers that use their own rate.