### PR TITLE
Orders: reprocess feature

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,8 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 
   config.before(:each) do |spec|
-    # puts spec.description
     StraightServer.db_connection[:orders].delete
+    StraightServer.db_connection[:gateways].delete
     logger_mock = double("logger mock")
     [:debug, :info, :warn, :fatal, :unknown, :blank_lines].each do |e|
       allow(logger_mock).to receive(e)


### PR DESCRIPTION
Reprocess expired order:

* Order status will be set according to newly found transactions
* Callback will run if status is actually changed

If there is newer order with the same address, all and only transactions which
couldn't belong to that newer order (their block_height < order's block_height_created_at)
will be taken into account.

Example usage:

```
bundle exec bin/straight-console
StraightServer::Order.last.reprocess!
```